### PR TITLE
Add declarative performance test scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ See [action.yml](action.yml)
     # Default: ''
     blueprint: ''
 
+    # JSON file defining browser scenarios to test.
+    #
+    # Default: ''
+    scenarios: ''
+
     # WordPress version to use.
     #
     # Loads the specified WordPress version.
@@ -200,6 +205,58 @@ Add a blueprint (`my-custom-blueprint.json`):
   ]
 }
 
+```
+
+Add browser scenarios (`my-scenarios.json`):
+
+```json
+{
+  "scenarios": [
+    {
+      "name": "Homepage LCP",
+      "steps": [
+        {
+          "step": "visit",
+          "url": "/"
+        }
+      ]
+    },
+    {
+      "name": "Search form INP",
+      "steps": [
+        {
+          "step": "visit",
+          "url": "/sample-page"
+        },
+        {
+          "step": "getByLabel",
+          "arg": "Search"
+        },
+        {
+          "step": "fill",
+          "arg": "Lorem ipsum"
+        },
+        {
+          "step": "getByRole",
+          "arg": "button",
+          "options": {
+            "name": "/Search/i"
+          }
+        },
+        {
+          "step": "click"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Use the scenario file in the workflow:
+
+```yaml
+with:
+  scenarios: ./my-scenarios.json
 ```
 
 ### Running tests in parallel (sharding)

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     required: false
     description: 'Blueprint to use for setting up the environment.'
     default: ''
+  scenarios:
+    required: false
+    description: 'JSON file defining browser scenarios to test.'
+    default: ''
   wp-version:
     required: false
     description: 'WordPress version to use.'
@@ -204,6 +208,7 @@ runs:
         SHARD: ${{ inputs.shard != '' && inputs.shard || '' }}
         ADDITIONAL_ARGS: ${{ inputs.shard != '' && format('-- --shard={0}', inputs.shard) || '' }}
         URLS_TO_TEST: ${{ inputs.urls }}
+        SCENARIOS_FILE: ${{ inputs.scenarios }}
         DEBUG: ${{ inputs.debug == 'true' }}
         TEST_ITERATIONS: ${{ inputs.iterations }}
         TEST_REPETITIONS: ${{ inputs.repetitions }}

--- a/env/tests/performance/specs/main.spec.ts
+++ b/env/tests/performance/specs/main.spec.ts
@@ -1,5 +1,6 @@
 import { test } from '@wordpress/e2e-test-utils-playwright';
 import { camelCaseDashes } from '../utils';
+import { loadScenarios, runScenario } from '../utils/scenarios';
 
 const results: Record< string, Record< string, number[] > > = {};
 
@@ -32,6 +33,7 @@ test.describe( 'Tests', () => {
 		.filter( Boolean );
 
 	const iterations = Number( process.env.TEST_ITERATIONS );
+	const scenariosToTest = loadScenarios();
 
 	for ( const url of urlsToTest ) {
 		for ( let i = 1; i <= iterations; i++ ) {
@@ -59,6 +61,38 @@ test.describe( 'Tests', () => {
 				results[ url ].timeToFirstByte.push( ttfb );
 				results[ url ].lcpMinusTtfb ??= [];
 				results[ url ].lcpMinusTtfb.push( lcp - ttfb );
+			} );
+		}
+	}
+
+	for ( const scenario of scenariosToTest ) {
+		for ( let i = 1; i <= iterations; i++ ) {
+			test( `Scenario: "${ scenario.name }" (${ i } of ${ iterations })`, async ( {
+				page,
+				metrics,
+			} ) => {
+				await runScenario( page, scenario, i );
+
+				const serverTiming = await metrics.getServerTiming();
+
+				results[ scenario.name ] ??= {};
+
+				for ( const [ key, value ] of Object.entries( serverTiming ) ) {
+					results[ scenario.name ][ camelCaseDashes( key ) ] ??= [];
+					results[ scenario.name ][ camelCaseDashes( key ) ].push(
+						value
+					);
+				}
+
+				const ttfb = await metrics.getTimeToFirstByte();
+				const lcp = await metrics.getLargestContentfulPaint();
+
+				results[ scenario.name ].largestContentfulPaint ??= [];
+				results[ scenario.name ].largestContentfulPaint.push( lcp );
+				results[ scenario.name ].timeToFirstByte ??= [];
+				results[ scenario.name ].timeToFirstByte.push( ttfb );
+				results[ scenario.name ].lcpMinusTtfb ??= [];
+				results[ scenario.name ].lcpMinusTtfb.push( lcp - ttfb );
 			} );
 		}
 	}

--- a/env/tests/performance/utils/scenarios.ts
+++ b/env/tests/performance/utils/scenarios.ts
@@ -1,0 +1,218 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import type { Locator, Page } from '@playwright/test';
+
+type LocatorOptions = Record< string, unknown >;
+
+export interface ScenarioStep {
+	step: string;
+	arg?: string;
+	role?: string;
+	selector?: string;
+	url?: string;
+	value?: string;
+	state?: 'load' | 'domcontentloaded' | 'networkidle';
+	timeout?: number;
+	options?: LocatorOptions;
+}
+
+export interface Scenario {
+	name: string;
+	steps: ScenarioStep[];
+}
+
+interface ScenarioFile {
+	scenarios?: Scenario[];
+}
+
+export function loadScenarios( filePath = process.env.SCENARIOS_FILE || '' ) {
+	if ( filePath.trim() === '' ) {
+		return [];
+	}
+
+	const resolvedPath = isAbsolute( filePath )
+		? filePath
+		: join( process.env.GITHUB_WORKSPACE || process.cwd(), filePath );
+
+	if ( ! existsSync( resolvedPath ) ) {
+		throw new Error( `Scenario file not found: ${ resolvedPath }` );
+	}
+
+	const data = JSON.parse(
+		readFileSync( resolvedPath, 'utf-8' )
+	) as ScenarioFile;
+
+	return ( data.scenarios || [] ).map( validateScenario );
+}
+
+export async function runScenario(
+	page: Page,
+	scenario: Scenario,
+	iteration: number
+) {
+	let locator: Locator | undefined;
+
+	for ( const step of scenario.steps ) {
+		locator = await runStep( page, step, iteration, locator );
+	}
+}
+
+async function runStep(
+	page: Page,
+	step: ScenarioStep,
+	iteration: number,
+	locator: Locator | undefined
+) {
+	switch ( step.step ) {
+		case 'visit':
+			await page.goto(
+				addIterationParam( getRequiredString( step, 'url' ), iteration )
+			);
+			return undefined;
+
+		case 'locator':
+			return page.locator( getRequiredString( step, 'selector' ) );
+
+		case 'getByLabel':
+			return page.getByLabel(
+				getRequiredString( step, 'arg' ),
+				normalizeOptions( step.options )
+			);
+
+		case 'getByPlaceholder':
+			return page.getByPlaceholder(
+				getRequiredString( step, 'arg' ),
+				normalizeOptions( step.options )
+			);
+
+		case 'getByText':
+			return page.getByText(
+				getRequiredString( step, 'arg' ),
+				normalizeOptions( step.options )
+			);
+
+		case 'getByRole':
+			return page.getByRole(
+				getRole( step ),
+				normalizeOptions( step.options ) as Parameters<
+					Page[ 'getByRole' ]
+				>[ 1 ]
+			);
+
+		case 'click':
+			await getLocator( locator, step ).click(
+				normalizeOptions( step.options )
+			);
+			return locator;
+
+		case 'fill':
+			await getLocator( locator, step ).fill(
+				getRequiredString( step, 'arg' ),
+				normalizeOptions( step.options )
+			);
+			return locator;
+
+		case 'press':
+			await getLocator( locator, step ).press(
+				getRequiredString( step, 'arg' ),
+				normalizeOptions( step.options )
+			);
+			return locator;
+
+		case 'hover':
+			await getLocator( locator, step ).hover(
+				normalizeOptions( step.options )
+			);
+			return locator;
+
+		case 'waitFor':
+			await getLocator( locator, step ).waitFor(
+				normalizeOptions( step.options )
+			);
+			return locator;
+
+		case 'waitForLoadState':
+			await page.waitForLoadState( step.state || 'load' );
+			return locator;
+
+		case 'waitForTimeout':
+			await page.waitForTimeout( step.timeout || 0 );
+			return locator;
+
+		case 'reload':
+			await page.reload();
+			return undefined;
+
+		case 'clearCookies':
+			await page.context().clearCookies();
+			return locator;
+
+		default:
+			throw new Error( `Unsupported scenario step: ${ step.step }` );
+	}
+}
+
+function validateScenario( scenario: Scenario ) {
+	if ( typeof scenario.name !== 'string' || scenario.name.trim() === '' ) {
+		throw new Error( 'Each scenario needs a non-empty name.' );
+	}
+
+	if ( ! Array.isArray( scenario.steps ) || scenario.steps.length === 0 ) {
+		throw new Error(
+			`Scenario "${ scenario.name }" needs at least one step.`
+		);
+	}
+
+	return scenario;
+}
+
+function getLocator( locator: Locator | undefined, step: ScenarioStep ) {
+	if ( ! locator ) {
+		throw new Error( `Step "${ step.step }" needs a locator first.` );
+	}
+
+	return locator;
+}
+
+function getRole( step: ScenarioStep ) {
+	return getRequiredString( step, step.role ? 'role' : 'arg' ) as Parameters<
+		Page[ 'getByRole' ]
+	>[ 0 ];
+}
+
+function getRequiredString( step: ScenarioStep, key: keyof ScenarioStep ) {
+	const value = step[ key ];
+	if ( typeof value !== 'string' || value.trim() === '' ) {
+		throw new Error(
+			`Step "${ step.step }" needs a non-empty "${ key }".`
+		);
+	}
+
+	return value;
+}
+
+function normalizeOptions( options: LocatorOptions = {} ) {
+	return Object.fromEntries(
+		Object.entries( options ).map( ( [ key, value ] ) => [
+			key,
+			parseOptionValue( value ),
+		] )
+	) as LocatorOptions;
+}
+
+function parseOptionValue( value: unknown ) {
+	if ( typeof value !== 'string' ) {
+		return value;
+	}
+
+	const regex = value.match( /^\/(.+)\/([a-z]*)$/i );
+
+	return regex ? new RegExp( regex[ 1 ], regex[ 2 ] ) : value;
+}
+
+function addIterationParam( url: string, iteration: number ) {
+	const withoutTrailingSlash = url === '/' ? '/' : url.replace( /\/$/, '' );
+	const separator = withoutTrailingSlash.includes( '?' ) ? '&' : '?';
+
+	return `${ withoutTrailingSlash }${ separator }i=${ iteration }`;
+}


### PR DESCRIPTION
## Summary
- Add a `scenarios` action input that points to a JSON file of browser steps.
- Execute scenario steps with Playwright before collecting the existing performance metrics.
- Document a scenario file example for visits, locators, fill, and click interactions.

## Verification
- `npx wp-scripts lint-js tests/performance/specs/main.spec.ts tests/performance/utils/scenarios.ts`
- `npx tsc --noEmit`
- `git diff --check`
- Local integration: mounted `Ultimate-Multisite/ultimate-multisite` into WordPress Playground with its existing `.github/performance-blueprint.json`, set `SCENARIOS_FILE` to a one-step scenario JSON, and ran `npm run test:performance` with `TEST_ITERATIONS=1` and `TEST_REPETITIONS=1`; Playwright reported `1 passed` and produced performance metrics for `Homepage scenario`.

Note: `npm run lint` still reports existing errors in untouched files (`tests/performance/cli/results.js`, `tests/performance/config/performance-reporter.ts`, and `tests/performance/playwright.config.ts`).

Closes #174

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.10 plugin for [OpenCode](https://opencode.ai) v1.14.41 spent 24m on this as a headless worker.
