### PR TITLE
Add CPU throttling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,13 @@ See [action.yml](action.yml)
     #
     # Default: 'latest'
     php-version: ''
- 
+
+    # CPU throttling rate to apply in Chromium.
+    # For example, 4 simulates a 4x CPU slowdown.
+    #
+    # Default: ''
+    cpu-throttling-rate: ''
+
     # Number of times the tests should be repeated.
     #
     # Default: 2

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     required: false
     description: 'PHP version to use.'
     default: '8.2'
+  cpu-throttling-rate:
+    required: false
+    description: 'CPU throttling rate to apply in Chromium.'
+    default: ''
   shard:
     required: false
     description: 'Shard to use if running tests in parallel in a matrix.'
@@ -204,6 +208,7 @@ runs:
         SHARD: ${{ inputs.shard != '' && inputs.shard || '' }}
         ADDITIONAL_ARGS: ${{ inputs.shard != '' && format('-- --shard={0}', inputs.shard) || '' }}
         URLS_TO_TEST: ${{ inputs.urls }}
+        CPU_THROTTLING_RATE: ${{ inputs.cpu-throttling-rate }}
         DEBUG: ${{ inputs.debug == 'true' }}
         TEST_ITERATIONS: ${{ inputs.iterations }}
         TEST_REPETITIONS: ${{ inputs.repetitions }}

--- a/env/tests/performance/specs/main.spec.ts
+++ b/env/tests/performance/specs/main.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { test } from '@wordpress/e2e-test-utils-playwright';
 import { camelCaseDashes } from '../utils';
 
@@ -32,13 +33,20 @@ test.describe( 'Tests', () => {
 		.filter( Boolean );
 
 	const iterations = Number( process.env.TEST_ITERATIONS );
+	const cpuThrottlingRate = getCpuThrottlingRate();
 
 	for ( const url of urlsToTest ) {
 		for ( let i = 1; i <= iterations; i++ ) {
 			test( `URL: "${ url }" (${ i } of ${ iterations })`, async ( {
+				browserName,
 				page,
 				metrics,
 			} ) => {
+				await applyCpuThrottling(
+					page,
+					browserName,
+					cpuThrottlingRate
+				);
 				await page.goto( `${ url.replace( /\/$/, '' ) }/?i=${ i }` );
 
 				const serverTiming = await metrics.getServerTiming();
@@ -63,3 +71,32 @@ test.describe( 'Tests', () => {
 		}
 	}
 } );
+
+function getCpuThrottlingRate() {
+	const rate = ( process.env.CPU_THROTTLING_RATE || '' ).trim();
+
+	if ( rate === '' ) {
+		return 0;
+	}
+
+	const parsedRate = Number( rate );
+
+	if ( ! Number.isFinite( parsedRate ) || parsedRate <= 0 ) {
+		throw new Error( 'CPU_THROTTLING_RATE must be a positive number.' );
+	}
+
+	return parsedRate;
+}
+
+async function applyCpuThrottling(
+	page: Page,
+	browserName: string,
+	rate: number
+) {
+	if ( rate === 0 || browserName !== 'chromium' ) {
+		return;
+	}
+
+	const session = await page.context().newCDPSession( page );
+	await session.send( 'Emulation.setCPUThrottlingRate', { rate } );
+}


### PR DESCRIPTION
## Summary
- Add a `cpu-throttling-rate` action input for Chromium runs.
- Apply Chrome DevTools Protocol CPU throttling before each measured navigation.
- Document the input with a 4x slowdown example.

## Verification
- `npx wp-scripts lint-js tests/performance/specs/main.spec.ts`
- `npx tsc --noEmit`
- `git diff --check`
- Local integration: mounted `Ultimate-Multisite/ultimate-multisite` into WordPress Playground with its existing `.github/performance-blueprint.json`, set `CPU_THROTTLING_RATE=4`, and ran `npm run test:performance` with `URLS_TO_TEST=/`, `TEST_ITERATIONS=1`, and `TEST_REPETITIONS=1`; Playwright reported `1 passed` and produced performance metrics for `/`.

Note: `npm run lint` still reports existing errors in untouched files (`tests/performance/cli/results.js`, `tests/performance/config/performance-reporter.ts`, and `tests/performance/playwright.config.ts`).

Closes #85

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.10 plugin for [OpenCode](https://opencode.ai) v1.14.41 spent 26m on this as a headless worker.
